### PR TITLE
Fixing the error of no audio backend when using conda on Windows.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ regex
 einops
 fvcore
 decord==0.6.0
+soundfile


### PR DESCRIPTION
Using the soundfile backend of torchaudio on the Windows platform, update requirements.txt.