### PR TITLE
 Update requirements.txt with pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ matplotlib
 types-regex
 mayavi
 cartopy
+pillow


### PR DESCRIPTION
There is currently a lack of pillow (PIL) in [requirements.txt](https://github.com/facebookresearch/ImageBind/blob/38a9132636f6ca2acdd6bb3d3c10be5859488f59/requirements.txt) despite import in [data.py](https://github.com/facebookresearch/ImageBind/blob/38a9132636f6ca2acdd6bb3d3c10be5859488f59/data.py).