### PR TITLE
reformat: change init transform to out of loop

### DIFF
--- a/imagebind/data.py
+++ b/imagebind/data.py
@@ -80,20 +80,22 @@ def load_and_transform_vision_data(image_paths, device):
         return None
 
     image_outputs = []
+
+    data_transform = transforms.Compose(
+        [
+            transforms.Resize(
+                224, interpolation=transforms.InterpolationMode.BICUBIC
+            ),
+            transforms.CenterCrop(224),
+            transforms.ToTensor(),
+            transforms.Normalize(
+                mean=(0.48145466, 0.4578275, 0.40821073),
+                std=(0.26862954, 0.26130258, 0.27577711),
+            ),
+        ]
+    )
+    
     for image_path in image_paths:
-        data_transform = transforms.Compose(
-            [
-                transforms.Resize(
-                    224, interpolation=transforms.InterpolationMode.BICUBIC
-                ),
-                transforms.CenterCrop(224),
-                transforms.ToTensor(),
-                transforms.Normalize(
-                    mean=(0.48145466, 0.4578275, 0.40821073),
-                    std=(0.26862954, 0.26130258, 0.27577711),
-                ),
-            ]
-        )
         with open(image_path, "rb") as fopen:
             image = Image.open(fopen).convert("RGB")
 


### PR DESCRIPTION
Hi,
I noticed that in this code, data_transform is being assigned multiple times unnecessarily within the loop. To eliminate redundant assignments, I have moved data_transform outside of the loop, reducing the need for it to be assigned multiple times. Now, it only needs to be assigned once.

Thank you for reviewing my pull request.