### PR TITLE
download imagebind_huge checkpoint to cache instead of local dir

### DIFF
--- a/imagebind/models/imagebind_model.py
+++ b/imagebind/models/imagebind_model.py
@@ -490,17 +490,18 @@ def imagebind_huge(pretrained=False):
     )
 
     if pretrained:
-        if not os.path.exists(".checkpoints/imagebind_huge.pth"):
+        cache_dir = os.path.expanduser("~/.cache/imagebind_checkpoints")
+        if not os.path.exists("%s/imagebind_huge.pth" % (cache_dir)):
             print(
-                "Downloading imagebind weights to .checkpoints/imagebind_huge.pth ..."
+                "Downloading imagebind weights to %s/imagebind_huge.pth ..." % (cache_dir)
             )
-            os.makedirs(".checkpoints", exist_ok=True)
+            os.makedirs(cache_dir, exist_ok=True)
             torch.hub.download_url_to_file(
                 "https://dl.fbaipublicfiles.com/imagebind/imagebind_huge.pth",
-                ".checkpoints/imagebind_huge.pth",
+                "%s/imagebind_huge.pth" % (cache_dir), 
                 progress=True,
             )
 
-        model.load_state_dict(torch.load(".checkpoints/imagebind_huge.pth"))
+        model.load_state_dict(torch.load("%s/imagebind_huge.pth" % (cache_dir)))
 
     return model


### PR DESCRIPTION
Download checkpoints for imagebind huge to cache (~/.cache) instead of local dir. This is how hugging face does it as well, for example. This way, the code is usable from anywhere and does not rely on a local .checkpoints/ directory. Also avoids cluttering the code with checkpoints dirs.