### PR TITLE
Add Hugging Face integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ device = "cuda:0" if torch.cuda.is_available() else "cpu"
 
 # Instantiate model
 model = ImageBindModel.from_pretrained("facebook/imagebind-huge")
-model.eval()
 model.to(device)
 
 # Load data

--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ Extract and compare features across modalities (e.g. Image, Text and Audio).
 ```python
 from imagebind import data
 import torch
-from imagebind.models import imagebind_model
-from imagebind.models.imagebind_model import ModalityType
+from imagebind.models.imagebind_model import ImageBindModel, ModalityType
 
 text_list=["A dog.", "A car", "A bird"]
 image_paths=[".assets/dog_image.jpg", ".assets/car_image.jpg", ".assets/bird_image.jpg"]
@@ -83,7 +82,7 @@ audio_paths=[".assets/dog_audio.wav", ".assets/car_audio.wav", ".assets/bird_aud
 device = "cuda:0" if torch.cuda.is_available() else "cpu"
 
 # Instantiate model
-model = imagebind_model.imagebind_huge(pretrained=True)
+model = ImageBindModel.from_pretrained("facebook/imagebind-huge")
 model.eval()
 model.to(device)
 

--- a/imagebind/models/imagebind_model.py
+++ b/imagebind/models/imagebind_model.py
@@ -24,6 +24,8 @@ from imagebind.models.multimodal_preprocessors import (AudioPreprocessor,
                                              ThermalPreprocessor)
 from imagebind.models.transformer import MultiheadAttention, SimpleTransformer
 
+from huggingface_hub import PyTorchModelHubMixin
+
 ModalityType = SimpleNamespace(
     VISION="vision",
     TEXT="text",
@@ -34,7 +36,7 @@ ModalityType = SimpleNamespace(
 )
 
 
-class ImageBindModel(nn.Module):
+class ImageBindModel(nn.Module, PyTorchModelHubMixin):
     def __init__(
         self,
         video_frames=2,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-torch==1.13.0
-torchvision==0.14.0
-torchaudio==0.13.0
-pytorchvideo @ git+https://github.com/facebookresearch/pytorchvideo.git@28fe037d212663c6a24f373b94cc5d478c8c1a1d
+# torch==1.13.0
+# torchvision==0.14.0
+# torchaudio==0.13.0
+# pytorchvideo @ git+https://github.com/facebookresearch/pytorchvideo.git@28fe037d212663c6a24f373b94cc5d478c8c1a1d
 timm==0.6.7
 ftfy
 regex

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-# torch==1.13.0
-# torchvision==0.14.0
-# torchaudio==0.13.0
-# pytorchvideo @ git+https://github.com/facebookresearch/pytorchvideo.git@28fe037d212663c6a24f373b94cc5d478c8c1a1d
+torch==1.13.0
+torchvision==0.14.0
+torchaudio==0.13.0
+pytorchvideo @ git+https://github.com/facebookresearch/pytorchvideo.git@28fe037d212663c6a24f373b94cc5d478c8c1a1d
 timm==0.6.7
 ftfy
 regex


### PR DESCRIPTION
Hi, thanks for this great model!

Currently models aren't easily discoverable, there are no ImageBind models on the 🤗 hub, so this PR proposes to leverage the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) which is a minimal class to add `from_pretrained` and `push_to_hub` capabilities to any custom `nn.Module`.

All you need to do is inherit from this class, and then you can do:

```python
from imagebind.models.imagebind_model import ImageBindModel

model = ImageBindModel.push_to_hub("nielsr/imagebind-huge")

reloaded_model = ImageBindModel.from_pretrained("nielsr/imagebind-huge")
```
This also comes with automated download metrics, meaning you will be able to see how many times people use each of the various ImageBind models.

The model is here for now: https://huggingface.co/nielsr/imagebind-huge, but we could push and move all checkpoints to the Meta [organization](https://huggingface.co/facebook) on the 🤗 hub. cc @liuzhuang13 

This is similar to what we did for Hiera, see https://github.com/facebookresearch/hiera/pull/26.

Kind regards,

Niels
ML @ HF