### PR TITLE
fix: Change encoding to UTF-8 for opening README.md in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     version='0.1.0',
     packages=find_packages(),
     description='A brief description of the package',
-    long_description=open('README.md').read(),
+    long_description=open('README.md', encoding='utf-8').read(),
     long_description_content_type="text/markdown",
     url='https://github.com/facebookresearch/ImageBind',
     classifiers=[


### PR DESCRIPTION
Thanks for nice repository!

This commit adjusts the encoding to UTF-8 for the 'open' command used to access the README.md file in the setup.py. The modification aims to ensure compatibility with the default language settings in Windows environments.

Regards,
Choyongchae