### PR TITLE
Update PyTorch version to support Python 3.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 **__pycache__
 .vscode
+.idea/
+.python-version
+build/
+imagebind.egg-info
 .DS_Store
+venv/

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Emergent zero-shot classification performance.
 Install pytorch 1.13+ and other 3rd party dependencies.
 
 ```shell
-conda create --name imagebind python=3.8 -y
+conda create --name imagebind python=3.10 -y
 conda activate imagebind
 
 pip install .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch==1.13.0
+torch==1.13.1
 torchvision==0.14.0
 torchaudio==0.13.0
 pytorchvideo @ git+https://github.com/facebookresearch/pytorchvideo.git@28fe037d212663c6a24f373b94cc5d478c8c1a1d

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 torch==1.13.1
-torchvision==0.14.0
-torchaudio==0.13.0
+torchvision  # because torch version already specific, the right torchvision will be derived automatically
+torchaudio  # because torch version already specific, the right torchaudio will be derived automatically
 pytorchvideo @ git+https://github.com/facebookresearch/pytorchvideo.git@28fe037d212663c6a24f373b94cc5d478c8c1a1d
 timm==0.6.7
 ftfy


### PR DESCRIPTION
Just a simple upgrade to 3.10. Torch is bumped from 1.13.0 to 1.13.1, which has all the different wheels for 3.10.

This solves two issues:
- Python 3.8 is 5 years old and nearing end of life later this year
- There are build issues with 3.8 caused by VTK which only has wheels from ARM processors from Python 3.9 and up (VTK wheels: https://pypi.org/project/vtk/#files, another user having the same issue: https://github.com/facebookresearch/ImageBind/issues/116).