### PR TITLE
Updated Package Dependencies & Resolved Deprecations

### DIFF
--- a/imagebind/data.py
+++ b/imagebind/data.py
@@ -16,7 +16,7 @@ from PIL import Image
 from pytorchvideo.data.clip_sampling import ConstantClipsPerVideoSampler
 from pytorchvideo.data.encoded_video import EncodedVideo
 from torchvision import transforms
-from torchvision.transforms._transforms_video import NormalizeVideo
+from torchvision.transforms.transforms import Normalize
 
 from imagebind.models.multimodal_preprocessors import SimpleTokenizer
 

--- a/imagebind/data.py
+++ b/imagebind/data.py
@@ -13,7 +13,6 @@ import torch
 import torch.nn as nn
 import torchaudio
 from PIL import Image
-from pytorchvideo import transforms as pv_transforms
 from pytorchvideo.data.clip_sampling import ConstantClipsPerVideoSampler
 from pytorchvideo.data.encoded_video import EncodedVideo
 from torchvision import transforms
@@ -341,3 +340,27 @@ def load_and_transform_video_data(
         video_outputs.append(all_video)
 
     return torch.stack(video_outputs, dim=0).to(device)
+
+class UniformTemporalSubsample(nn.Module):
+    """
+    ``nn.Module`` wrapper for ``pytorchvideo.transforms.functional.uniform_temporal_subsample``.
+    """
+
+    def __init__(self, num_samples: int, temporal_dim: int = -3):
+        """
+        Args:
+            num_samples (int): The number of equispaced samples to be selected
+            temporal_dim (int): dimension of temporal to perform temporal subsample.
+        """
+        super().__init__()
+        self._num_samples = num_samples
+        self._temporal_dim = temporal_dim
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Args:
+            x (torch.Tensor): video tensor with shape (C, T, H, W).
+        """
+        return pytorchvideo.transforms.functional.uniform_temporal_subsample(
+            x, self._num_samples, self._temporal_dim
+        )

--- a/imagebind/models/multimodal_preprocessors.py
+++ b/imagebind/models/multimodal_preprocessors.py
@@ -18,7 +18,7 @@ import regex as re
 import torch
 import torch.nn as nn
 from iopath.common.file_io import g_pathmgr
-from timm.models.layers import trunc_normal_
+from timm.layers import trunc_normal_
 
 from imagebind.models.helpers import VerboseNNModule, cast_if_src_dtype
 

--- a/imagebind/models/transformer.py
+++ b/imagebind/models/transformer.py
@@ -17,7 +17,7 @@ from typing import Callable, List, Optional
 import torch
 import torch.nn as nn
 import torch.utils.checkpoint as checkpoint
-from timm.models.layers import DropPath, trunc_normal_
+from timm.layers import DropPath, trunc_normal_
 
 
 class Attention(nn.Module):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,15 @@
-torch==1.13.1
+torch
 torchvision  # because torch version already specific, the right torchvision will be derived automatically
 torchaudio  # because torch version already specific, the right torchaudio will be derived automatically
 pytorchvideo @ git+https://github.com/facebookresearch/pytorchvideo.git@28fe037d212663c6a24f373b94cc5d478c8c1a1d
-timm==0.6.7
+timm
 ftfy
 regex
 einops
 fvcore
-eva-decord==0.6.1
+eva-decord
 iopath
-numpy>=1.19
+numpy
 matplotlib
 types-regex
 mayavi


### PR DESCRIPTION
##  Replaced unnecessary import with appropriate class

`1`. in imagebind/data.py
- Instead of importing the entire module, only the `UniformTemporalSubsample` class was imported, as it was the only class needed.

## Replaced deprecated function:
   `2`. in imagebind/data.py:
- Changed `torchvision.transforms._transforms_video.NormalizeVideo` to `torchvision.transforms.transforms.Normalize`.

`3`. In imagebind/models/transformers.py file:
-  Changed `timm.models.layers` to `timm.layers`
 
 `4`. In imagebind/models/multimodal_preprocessors.py file:
 -  Changed `timm.models.layers` to `timm.layers`.